### PR TITLE
error: lvalue required as left operand of assignment

### DIFF
--- a/Thirdparty/sophus/sophus/so2.cpp
+++ b/Thirdparty/sophus/sophus/so2.cpp
@@ -29,8 +29,7 @@ namespace Sophus
 
 SO2::SO2()
 {
-  unit_complex_.real() = 1.;
-  unit_complex_.imag() = 0.;
+  unit_complex_ = std::complex<double>(1,0);
 }
 
 SO2


### PR DESCRIPTION
sophus/so2.cpp: In constructor ‘Sophus::SO2::SO2()’:
sophus/so2.cpp:32:21: error: lvalue required as left operand of assignment
   32 |   unit_complex_.real() = 1.;
      |   ~~~~~~~~~~~~~~~~~~^~
sophus/so2.cpp:33:21: error: lvalue required as left operand of assignment
   33 |   unit_complex_.imag() = 0.;
      |   ~~~~~~~~~~~~~~~~~~^~
this fixes that